### PR TITLE
Fix 2x-nested translation of record list fields

### DIFF
--- a/src/erlsom_type2xsd.erl
+++ b/src/erlsom_type2xsd.erl
@@ -237,8 +237,8 @@ translateType({type, _, union, Alternatives}, Tns) ->
   end;
 
 translateType({type, _, list, [Element]}, Tns) ->
-  TranslatedElement = translateType(Element, Tns),
-  {TranslatedElement, "0", "unbounded"};
+  {Type, _, _} = translateType(Element, Tns),
+  {Type, "0", "unbounded"};
 translateType({type, _, record, [{atom, _, RecordType}]}, Tns) ->
   {qname(atom_to_list(RecordType), Tns),
     undefined, undefined};


### PR DESCRIPTION
Upstream PR: https://github.com/willemdj/erlsom/pull/94

For bet365/soap#47

When using `soap:erlang2wsdl` on the referenced `.hrl`, a crash occurs as described in the above issue. This is because the nesting of the translated `hobbies` field is doubled up; the return value from `erlsom_type2xsd:translateType/2` has the `MinOccurs`/`MaxOccurs` wrapper applied twice for lists.

Ignore the list element type's `MinOccurs`/`MaxOccurs` and use the 0 and unbounded values, for lists, respectively. This will produce the same result as shown on https://github.com/bet365/soap/blob/6848d29d9d123c37f22b309f19de848f6309b66a/doc/generating_a_wsdl.md?plain=1#L160.

[Source .hrl](https://github.com/bet365/soap/blob/856b5c418d8d40a6b5bcbbe3fd390c6a0b8d4f18/test/soap_SUITE_data/store.hrl)